### PR TITLE
Composer support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,35 @@ Adaptors provide the necessary interface to communicate with different devices.
 Details on how to get started with device adaptors is available
 in the [wiki](https://github.com/openmsa/Device-Adaptors/wiki).
 
+Installing via Composer
+-----------------------
+
+If you like to use [Composer](https://getcomposer.org/) in your PHP projects, you can also use this to install device adaptors into your OpenMSA installation.  Here is a sample _composer.json_ file to run in your environment:
+
+	{
+	    "repositories": [
+	        {
+	            "type": "vcs",
+	            "url": "https://github.com/openmsa/Device-Adaptors"
+	        }
+	    ],
+	    "config": {
+	        "vendor-dir": "/opt/sms/bin/php/"
+	    },
+	    "require": {
+	        "openmsa/adaptors": "v1.1.1"
+	    }
+	}
+
+Now run the following to install version 1.1.1 of the adaptors into your local OpenMSA installation (note they will be installed into the _/opt/sms/bin/php/openmsa/adaptors/_ directory):
+
+	$ composer install
+	Loading composer repositories with package information
+	Installing dependencies (including require-dev) from lock file
+	Package operations: 1 install, 0 updates, 0 removals
+	  - Installing openmsa/adaptors (v1.1.1): Downloading (100%)
+	Generating autoload files
+
 
 Contributing to OpenMSA
 -----------------------

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,8 @@
+{
+    "name": "openmsa/adaptors",
+    "type": "library",
+    "description": "Low level abstraction layer for multi-vendor, multi-domain device management",
+    "keywords": ["device","adaptors","msa","openmsa","automation"],
+    "homepage": "https://www.openmsa.co/",
+    "license": "GPL-3.0"
+}


### PR DESCRIPTION
Adds initial Composer support including the following:

1. A composer.json file containing meta-data about this repo, including the new "openmsa/adaptors" namespace.
2. An updated README.md file containing a sample composer.json that a user can use in their MSA to enable them to download and install adaptors via the "composer install/update" commands.

Note I have tested installing from my Github fork to my local machine and it works well.

Note the following points that still need to be addressed:

1. Composer likes tags in the semver (https://semver.org/) format, so "1.0.0" or "v1.0.0" are valid examples, but the existing OpenMSA tags "openmsa-1.0" are invalid and Composer will complain about that.  In my repo I created a new "v1.1.1" patch tag to test that it was working, in the main repo we might have to rename the existing tags (or create a new patch tag as I have.
2. The adaptors are installed into _/opt/sms/bin/php/openmsa/adaptors/_ rather than _/opt/sms/bin/php/_, as Composer automatically creates directories for namespaces too in order to prevent different libs from clashing in the installation vendor directory.  MSA may need to be updated accordingly?