### PR TITLE
Fix generic rest installation

### DIFF
--- a/adapters/rest_generic/conf/device.properties
+++ b/adapters/rest_generic/conf/device.properties
@@ -4,3 +4,4 @@ manufacturer.id = 191119
 manufacturer.name = REST
 
 obsolete = false
+wizard = true	

--- a/adapters/rest_generic/conf/device.properties
+++ b/adapters/rest_generic/conf/device.properties
@@ -4,4 +4,4 @@ manufacturer.id = 191119
 manufacturer.name = REST
 
 obsolete = false
-wizard = true	
+

--- a/bin/da_installer
+++ b/bin/da_installer
@@ -98,7 +98,7 @@ update_models_properties() {
 
 	fixup_no_newline_at_eof $target_file
 
-	echo $MOD_ID,$MAN_ID,'"'$MOD_NAME'","H",0,0,0,0,0,1,0,0,0,0,0,SR,0,0' >> $target_file
+	echo $MOD_ID,$MAN_ID,'"'$MOD_NAME'","H",0,1,1,0,0,1,0,1,0,1,1,U,0,1' >> $target_file
 
 }
 


### PR DESCRIPTION
try to fix the installer to have the Generic REST device listed in WF when variable is typed "Device"